### PR TITLE
Some minor fixes / changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ dist
 *.s
 test/svcomp/*.l
 test/svcomp/*.ll
+test/*
+*.log
+.stack-work/*
+trcache/*
+log/*
+TAGS

--- a/Benchmarks.hs
+++ b/Benchmarks.hs
@@ -98,6 +98,9 @@ _DEFAULT_LOGDIR_ = "log/"
 _VERIFY_OPTS_ :: T.Text
 _VERIFY_OPTS_ = " -v5 --stats --timeout=200s"
 
+_ENCODE_OPTS_ :: T.Text
+_ENCODE_OPTS_ = ""
+
 getAllBenchmarks :: BenchConf -> IO [Benchmark]
 getAllBenchmarks conf =
   liftIO $ Turtle.fold
@@ -153,8 +156,8 @@ runBench conf = do
                                      True ->
                                          vvtBinary
                                          <> " encode -o " <> dest
-                                         <> " --ineq "
-                                         <> benchAsTxt
+                                         <> _ENCODE_OPTS_
+                                         <> " " <> benchAsTxt
                                          <> " > /dev/null" <> " 2>&1"
                                      False ->
                                          vvtBinary
@@ -162,7 +165,7 @@ runBench conf = do
                                          <> benchAsTxt
                                          <> " | " <> vvtenc
                                          <> " 2>/dev/null "
-                                         <> " | " <> vvtpreds <> " --ineq"
+                                         <> " | " <> vvtpreds <> _ENCODE_OPTS_
                                          <> " | " <> vvtpp
                                          <> " 1> " <> dest
                            in do

--- a/Benchmarks.hs
+++ b/Benchmarks.hs
@@ -96,7 +96,7 @@ _DEFAULT_LOGDIR_ :: FilePath
 _DEFAULT_LOGDIR_ = "log/"
 
 _VERIFY_OPTS_ :: T.Text
-_VERIFY_OPTS_ = " -v5 --stats --timeout=100s"
+_VERIFY_OPTS_ = " -v5 --stats --timeout=200s"
 
 getAllBenchmarks :: BenchConf -> IO [Benchmark]
 getAllBenchmarks conf =

--- a/Benchmarks.hs
+++ b/Benchmarks.hs
@@ -153,7 +153,7 @@ runBench conf = do
                                      True ->
                                          vvtBinary
                                          <> " encode -o " <> dest
-                                         <> " -i "
+                                         <> " --ineq "
                                          <> benchAsTxt
                                          <> " > /dev/null" <> " 2>&1"
                                      False ->
@@ -162,7 +162,7 @@ runBench conf = do
                                          <> benchAsTxt
                                          <> " | " <> vvtenc
                                          <> " 2>/dev/null "
-                                         <> " | " <> vvtpreds <> " -i"
+                                         <> " | " <> vvtpreds <> " --ineq"
                                          <> " | " <> vvtpp
                                          <> " 1> " <> dest
                            in do

--- a/Benchmarks.hs
+++ b/Benchmarks.hs
@@ -96,7 +96,7 @@ _DEFAULT_LOGDIR_ :: FilePath
 _DEFAULT_LOGDIR_ = "log/"
 
 _VERIFY_OPTS_ :: T.Text
-_VERIFY_OPTS_ = " -v5 --stats"
+_VERIFY_OPTS_ = " -v5 --stats --timeout=100s"
 
 getAllBenchmarks :: BenchConf -> IO [Benchmark]
 getAllBenchmarks conf =
@@ -152,7 +152,8 @@ runBench conf = do
                                    case bc_optimizeTr conf of
                                      True ->
                                          vvtBinary
-                                         <> " encode -o " <> dest <> " "
+                                         <> " encode -o " <> dest
+                                         <> " -i "
                                          <> benchAsTxt
                                          <> " > /dev/null" <> " 2>&1"
                                      False ->

--- a/CTIGAR.hs
+++ b/CTIGAR.hs
@@ -1147,7 +1147,7 @@ elimSpuriousTrans st level = do
   updateStats (\stats -> stats { numRefinements = (numRefinements stats)+1
                                , numAddPreds = (numAddPreds stats)+(length props) })
   interp <- interpolateState level (stateLifted rst) (stateLiftedInputs rst)
-  ic3Debug 4 $ "mined new predicates: " ++ (show (length props))
+  ic3Debug 4 $ "mined new predicates: " ++ (show props)
   ic3Debug 4 $ "computed interpolant: " ++ (show interp)
   domain <- gets ic3Domain
   order <- gets ic3LitOrder

--- a/vvt.cabal
+++ b/vvt.cabal
@@ -49,7 +49,7 @@ Library
     LitOrder
     Simplify
     Stats
-  GHC-Options: -fwarn-unused-imports
+  GHC-Options: -fwarn-unused-imports -fwarn-unused-binds
   Build-Depends:
     base,mtl,linear,containers,vector,transformers,attoparsec,bytestring,atto-lisp,text,dependent-sum,smtlib2 >= 1.0 && < 1.1,smtlib2-pipe >= 1.0 && < 1.1,smtlib2-debug >= 1.0 && < 1.1,smtlib2-timing >= 1.0 && < 1.1,bindings-llvm,fgl,dependent-map,resource-pool,pqueue,time,yaml,aeson,aeson-pretty,cassava,utf8-string
   Extensions:


### PR DESCRIPTION
Added a timeout of 200s per default and a macro for options to vvt encode, which is empty per default, to the benchmark script.
Turned on warnings on unused binds.
Removed some code that seems dead.
